### PR TITLE
chore: update node version to 12.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.19
+FROM node:12.18
 
 # install open jdk
 RUN apt-get update && \
@@ -30,8 +30,8 @@ RUN firebase setup:emulators:firestore
 RUN apt-get update && apt-get install -y apt-transport-https gnupg curl lsb-release
 
 RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
-  echo "cloud SDK repo: $CLOUD_SDK_REPO" && \
-  echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-  curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-  apt-get update -y && apt-get install google-cloud-sdk -y
+    echo "cloud SDK repo: $CLOUD_SDK_REPO" && \
+    echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+    apt-get update -y && apt-get install google-cloud-sdk -y
 


### PR DESCRIPTION
commintlint@11 需要 node >=10.22.0，就直接升到和其他 service 一樣的 12.18
![image](https://user-images.githubusercontent.com/6175880/95719174-0b5fe000-0ca2-11eb-9b37-ee9fc6a982b4.png)
